### PR TITLE
fixed startup-failure on osx

### DIFF
--- a/UndercoverPlaner.plt
+++ b/UndercoverPlaner.plt
@@ -159,10 +159,6 @@
                        [style '(no-focus control-border)]
                        ))
 
-(send (send my-canvas get-dc) set-origin 200 200)
-(send (send my-canvas get-dc) set-scale 1.8 1.8)
-
-
 (define upper-thickn (new combo-field% [parent right-panel]
                           [label "Dicke &oberes Brett in [mm]"]
                           [init-value "18"]
@@ -242,3 +238,6 @@
 
 
 (send frame show #t)
+
+(send (send my-canvas get-dc) set-origin 200 200)
+(send (send my-canvas get-dc) set-scale 1.8 1.8)


### PR DESCRIPTION
On OSX UndercoverPlaner fails with the following error at startup:

Drawingcontext must not be modified before frame is shown.

```
my-mbp-2:bin user$ ./gracket
~/Downloads/Undercover-Planer-master/UndercoverPlaner.plt
CGLayerRef->C: argument is not non-null `CGLayerRef' pointer
argument: #f
context...:
/Applications/Racket v6.4/collects/ffi/unsafe.rkt:1231:12
/Applications/Racket v6.4/collects/ffi/unsafe/alloc.rkt:30:8
/Applications/Racket
v6.4/collects/racket/private/more-scheme.rkt:265:2:
call-with-exception-handler
...safe/nsalloc.rkt:16:25
/Applications/Racket
v6.4/share/pkgs/gui-lib/mred/private/wx/cocoa/dc.rkt:307:0: make-layer
/Applications/Racket
v6.4/share/pkgs/gui-lib/mred/private/wx/cocoa/dc.rkt:161:2
/Applications/Racket
v6.4/collects/racket/private/class-internal.rkt:3557:0:
continue-make-object
/Applications/Racket
v6.4/collects/racket/private/class-internal.rkt:3511:0: do-make-object
/Applications/Racket
v6.4/share/pkgs/gui-lib/mred/private/wx/common/backing-dc.rkt:120:4:
get-cr method in backing-dc%
/Applications/Racket
v6.4/share/pkgs/draw-lib/racket/draw/private/dc.rkt:461:4: set-origin
method in dc%
/Applications/Racket
v6.4/share/pkgs/draw-lib/racket/draw/private/record-dc.rkt:596:4:
set-origin method in ...rivate/record-dc.rkt:356:2
/Users/user/Downloads/Undercover-Planer-master/UndercoverPlaner.plt:
[running body]
```
